### PR TITLE
[CPL-17718] Upgrade dependencies of `tap-linkedin-ads` tap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ setup(name='tap-linkedin-ads',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_linkedin_ads'],
       install_requires=[
-          'backoff==1.8.0',
-          'requests>=2.31.0',
-          'singer-python==5.12.1'
+          'singer-python@git+https://github.com/railsware/singer-python/@ea0489dcb73fcb19195eea50eeff9a13d6914e9a',
+          'requests>=2.26.0',
+          'backoff~=2.2.1',
       ],
       extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-linkedin-ads',
       py_modules=['tap_linkedin_ads'],
       install_requires=[
           'singer-python@git+https://github.com/railsware/singer-python/@ea0489dcb73fcb19195eea50eeff9a13d6914e9a',
-          'requests>=2.26.0',
+          'requests>=2.31.0',
           'backoff~=2.2.1',
       ],
       extras_require={


### PR DESCRIPTION
Required to use in incremental

[ticket](https://railsware.atlassian.net/browse/CPL-17718)
### Problem/domain

Upgrade to resolve conflicts with transient dependencies in the `coupler-io-serverless` repo.

### Tech changes

Upgrade `singer-python`, `requests` and `backoff` packages.