### PR TITLE
[CPL-25110] Add spotlight property to creatives schema

### DIFF
--- a/tap_linkedin_ads/schemas/creatives.json
+++ b/tap_linkedin_ads/schemas/creatives.json
@@ -68,6 +68,21 @@
               ]
             }
           }
+        },
+        "spotlight": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "landing_page": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
         }
       }
     },


### PR DESCRIPTION


# Description of change
- Add a new 'spotlight' property to tap_linkedin_ads/schemas/creatives.json. The field accepts null or an object with a nullable 'landing_page' string and disallows additional properties, enabling validation for spotlight creatives.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
