### PR TITLE
[CPL-25229] Add headline and call_to_action to creatives spotlight schema

### DIFF
--- a/tap_linkedin_ads/schemas/creatives.json
+++ b/tap_linkedin_ads/schemas/creatives.json
@@ -76,6 +76,18 @@
           ],
           "additionalProperties": false,
           "properties": {
+            "headline": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "call_to_action": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "landing_page": {
               "type": [
                 "null",


### PR DESCRIPTION
# Description of change
https://railsware.atlassian.net/browse/CPL-25229

Add `headline` and `call_to_action` properties to `content.spotlight` in the creatives schema, alongside the existing `landing_page` field.

# Manual QA steps
 - Run discovery and confirm the new fields appear under `content.spotlight` for the creatives stream.
 - Sync a creative with spotlight content and verify `headline` and `call_to_action` are emitted when present in the LinkedIn API response.

# Risks
 - None — purely additive schema change; existing records without these fields remain valid.

# Rollback steps
 - revert this branch